### PR TITLE
Evaluate `zod` vs `io-ts` runtime performance for route params

### DIFF
--- a/x-pack/platform/plugins/shared/observability_solution/observability_ai_assistant/server/routes/chat/test_type_perf.ts
+++ b/x-pack/platform/plugins/shared/observability_solution/observability_ai_assistant/server/routes/chat/test_type_perf.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// import * as t from 'io-ts';
+import { z } from '@kbn/zod';
+
+import { /* chatCompleteInternalRt, */ chatCompleteInternalZod } from './route';
+
+// const ioTsVar: t.TypeOf<typeof chatCompleteInternalRt> = {
+// }
+
+const zodTsVar: z.infer<typeof chatCompleteInternalZod> = {
+  // Invoke autocompletion here for analysis
+};


### PR DESCRIPTION
## Summary

This change is to compare the runtime TS performance analysis between `io-ts` and `zod`. An equivalent zod  params schema is created for the comparison.

`test_type_perf.ts` is where both schemas are invoked for each case with TS tracing on and the elapsed times for TS commands are recorded. TypeScript server is restarted before each case to capture the fresh logs.

Here's the summary of executed commands with their average times:

<table>
<thead>
<tr><th></th><th colspan=2> io-ts </th><th colspan=2> zod </th></tr>
<tr><th>command</th><th>avg. Time elapsed (ms)</th><th>count</th><th>avg. Time elapsed (ms)</th><th>count</th></tr>
</thead>

<tbody>

<tr><td>completionEntryDetails </td><td align=right>72.9786</td><td align=right>7</td><td align=right>23.3129</td><td align=right>6</td></tr>
<tr><td>completionInfo </td><td align=right>298.4030</td><td align=right>6</td><td align=right>256.1105</td><td align=right>4</td></tr>
<tr><td>configure </td><td align=right>0.1933</td><td align=right>1</td><td align=right>0.1986</td><td align=right>1</td></tr>
<tr><td>documentHighlights </td><td align=right>0.5562</td><td align=right>1</td><td align=right>0.5033</td><td align=right>1</td></tr>
<tr><td>getApplicableRefactors </td><td align=right>0.8880</td><td align=right>17</td><td align=right>1.2216</td><td align=right>9</td></tr>
<tr><td>getCodeFixes </td><td align=right>13.8945</td><td align=right>5</td><td align=right>21.1529</td><td align=right>4</td></tr>
<tr><td>updateOpen </td><td align=right>311.9281</td><td align=right>17</td><td align=right>338.519</td><td align=right>16</td></tr>

</tbody>
</table>