### PR TITLE
Keep XY settings in ES|QL charts when columns change

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/helpers.ts
@@ -141,6 +141,21 @@ export function mergeSuggestionWithVisContext({
   );
 
   if (hasInvalidColumns) {
+    // Columns changed — we can't reuse the old datasource state or layer accessors,
+    // but we can preserve column-independent appearance settings (legend, axis, grid, etc.)
+    if (suggestion.visualizationId === visAttributes.visualizationType) {
+      const savedVizState = visAttributes.state.visualization as Record<string, unknown>;
+      const suggestionVizState = suggestion.visualizationState as Record<string, unknown>;
+      // Only merge properties that don't reference columns (skip layers, accessors, etc.)
+      const { layers, ...appearanceSettings } = savedVizState;
+      return {
+        ...suggestion,
+        visualizationState: {
+          ...suggestionVizState,
+          ...appearanceSettings,
+        },
+      };
+    }
     return suggestion;
   }
 

--- a/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/index.ts
+++ b/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/index.ts
@@ -70,23 +70,13 @@ export const suggestionsApi = ({
 
   const query = 'query' in context ? context.query : undefined;
 
-  // When preferred visualization attributes are provided, pass the prior visualization state
-  // so that each visualization's suggestion logic can preserve its own settings (e.g. XY chart
-  // preserves legend, axis titles, etc. via its buildSuggestion when it receives currentState).
-  const preferredVisualization = preferredVisAttributes
-    ? visualizationMap[preferredVisAttributes.visualizationType] ?? initialVisualization
-    : initialVisualization;
-  const previousVisualizationState = preferredVisAttributes
-    ? preferredVisAttributes.state.visualization
-    : undefined;
-
   // find the active visualizations from the context
   const suggestions = getSuggestions({
     datasourceMap,
     datasourceStates,
     visualizationMap,
-    activeVisualization: preferredVisualization,
-    visualizationState: previousVisualizationState,
+    activeVisualization: initialVisualization,
+    visualizationState: undefined,
     visualizeTriggerFieldContext: context,
     subVisualizationId: isInitialSubTypeSupported ? preferredChartType?.toLowerCase() : undefined,
     dataViews,


### PR DESCRIPTION
## Summary

Keeps the XY settings if possible when XY charts columns change


